### PR TITLE
Feature/verx rh tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ git clone https://github.com/gabriel-silveira/mcp-server.git .
 ### 4.2. Configurar ambiente virtual
 
 ```bash
-python3 -m venv venv
-source venv/bin/activate
+python3 -m venv .venv
+source .venv/bin/activate
 ```
 
 ### 4.3. Instalar dependências
@@ -72,7 +72,7 @@ source venv/bin/activate
 ```bash
 pip install --upgrade pip
 pip install uv
-uv pip install -e ".[dev]"
+uv sync
 
 # Verificar se o Gunicorn foi instalado corretamente
 which gunicorn || pip install gunicorn
@@ -117,8 +117,8 @@ After=network.target
 User=root
 Group=root
 WorkingDirectory=/home/ubuntu/mcp
-Environment="PATH=/home/ubuntu/mcp/venv/bin"
-ExecStart=/home/ubuntu/mcp/venv/bin/gunicorn \
+Environment="PATH=/home/ubuntu/mcp/.venv/bin"
+ExecStart=/home/ubuntu/mcp/.venv/bin/gunicorn \
     --workers 4 \
     --worker-class uvicorn.workers.UvicornWorker \
     --bind 127.0.0.1:2906 \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,19 +5,23 @@ description = "Servidor MCP (Model Context Protocol) para integração com ferra
 readme = "README.md"
 requires-python = ">=3.12.4"
 dependencies = [
-    "langgraph>=0.5.1",
+    "langgraph>=0.6.4",
     "langchain-arcade>=1.3.1",
+    "langchain-community>=0.3.27",
+    "langchain-core>=0.3.74",
+    "langchain-openai>=0.2.5",
     "python-dotenv>=1.1.0",
     "fastapi>=0.115.12",
     "uvicorn[standard]==0.34.3",
     "gunicorn==21.2.0",
     "pyjwt>=2.10.1",
     "python-multipart>=0.0.20",
-    "langchain-openai>=0.2.5",
     "crewai>=0.141.0",
     "crewai-tools>=0.51.1",
     "youtube-transcript-api>=1.1.1",
-    "yt_dlp==2023.11.14"
+    "yt_dlp==2023.11.14",
+    "mariadb>=1.1.13",
+    "sqlalchemy>=2.0.43",
 ]
 
 [project.optional-dependencies]

--- a/src/config.py
+++ b/src/config.py
@@ -12,6 +12,7 @@ import os
 # API Keys
 ARCADE_API_KEY = os.getenv('ARCADE_API_KEY')
 OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
+MARIADB_URI = os.getenv('MARIADB_URI')
 
 # JWT Authentication
 SECRET_KEY = os.getenv('JWT_SECRET_KEY', "chave_secreta_muito_segura")  # Use uma chave gerada com openssl rand -hex 32

--- a/src/services/database.py
+++ b/src/services/database.py
@@ -1,0 +1,26 @@
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+from langchain_community.utilities import SQLDatabase
+from src.config import MARIADB_URI
+
+# --------- Conexão com MariaDB ---------
+def build_engine() -> Engine:
+    uri = MARIADB_URI
+    assert uri, "Defina MARIADB_URI"
+    engine = create_engine(
+        uri,
+        pool_size=5,
+        max_overflow=10,
+        pool_pre_ping=True,
+        pool_recycle=1800,  # evita conexões zumbis
+        connect_args={"connect_timeout": 5},
+    )
+    return engine
+
+ENGINE: Engine = build_engine()
+
+DB = SQLDatabase.from_uri(
+    MARIADB_URI,
+    sample_rows_in_table_info=2,
+)
+

--- a/src/services/nl2sql.py
+++ b/src/services/nl2sql.py
@@ -1,0 +1,335 @@
+"""
+Exporta o catálogo de um banco MariaDB para uso em LLMs (NL→SQL).
+- Coleta: tabelas, colunas (tipo/nullable/default/comentários), PK, FKs, índices, comentários.
+- Saídas: JSON (sempre) e Markdown (opcional).
+- Amostragem de linhas (opcional) para dar contexto de valores típicos.
+
+Uso:
+  python db_schema.py \
+    --url "mariadb+mariadbconnector://user:pass@host:3306/meu_schema" \
+    --schema meu_schema \
+    --out-json catalog.json \
+    --out-md catalog.md \
+    --include-views \
+    --sample-rows 3 \
+    --mask-pii \
+    --max-text-len 160
+
+Observações de segurança:
+- O script só realiza leitura de metadados e (se habilitado) SELECT com LIMIT.
+- Ideal rodar com usuário de leitura (read-only).
+"""
+
+from __future__ import annotations
+import json
+import re
+from typing import Any, Dict, List, Optional
+from datetime import datetime, date, time, timedelta
+from decimal import Decimal
+import uuid
+
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.engine import Engine
+from sqlalchemy.exc import SQLAlchemyError
+
+
+# ------------------------------- Utilidades ----------------------------------
+
+
+def guess_schema_from_url(engine: Engine) -> Optional[str]:
+    """Tenta obter o schema padrão via SELECT DATABASE()."""
+    try:
+        with engine.connect() as conn:
+            return conn.execute(text("SELECT DATABASE()")).scalar()
+    except Exception:
+        return None
+
+
+def normalize_type(t: Any) -> str:
+    """
+    Converte o tipo do SQLAlchemy para string estável e normalizada (minúsculas).
+    Observação: se o driver devolver ENUM sem os valores, manteremos "enum" simples.
+    """
+    try:
+        s = str(t)
+    except Exception:
+        s = repr(t)
+    return s.strip().lower()
+
+
+def json_fallback(o):
+    """Converte objetos não-serializáveis do Python para representações JSON-safe."""
+    if isinstance(o, (datetime, date, time)):
+        return o.isoformat()
+    if isinstance(o, timedelta):
+        return o.total_seconds()
+    if isinstance(o, Decimal):
+        return float(o)
+    if isinstance(o, (bytes, bytearray, memoryview)):
+        return o.decode("utf-8", "replace")
+    if isinstance(o, (set, tuple)):
+        return list(o)
+    if isinstance(o, uuid.UUID):
+        return str(o)
+    return str(o)
+
+
+# Regex simples para PII comum no BR
+EMAIL_RE = re.compile(r"[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}", re.I)
+CPF_RE = re.compile(r"\b\d{3}\.?\d{3}\.?\d{3}-?\d{2}\b")
+PHONE_RE = re.compile(r"\b(?:\+?55\s?)?(?:\(?\d{2}\)?\s?)?(?:9?\d{4}[-\s]?\d{4})\b")
+
+
+def mask_pii_value(v: Any, max_len: Optional[int]) -> Any:
+    """Masca e normaliza valores de texto para evitar PII em sample_rows."""
+    if v is None:
+        return None
+    if isinstance(v, (int, float, bool, Decimal)):
+        return v
+    s = json_fallback(v)  # já resolve datetime/bytes/etc
+    s = EMAIL_RE.sub("[email]", s)
+    s = CPF_RE.sub("[cpf]", s)
+    s = PHONE_RE.sub("[phone]", s)
+    # achatar quebras de linha e espaços excessivos
+    s = re.sub(r"\s+", " ", s).strip()
+    if max_len and len(s) > max_len:
+        s = s[:max_len] + "…"
+    return s
+
+
+def load_fk_rules(engine: Engine, schema: str) -> Dict[str, Dict[str, Optional[str]]]:
+    """
+    (2) Carrega UPDATE_RULE e DELETE_RULE por CONSTRAINT_NAME para o schema,
+    a partir de INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS.
+    """
+    q = text("""
+        SELECT CONSTRAINT_NAME, UPDATE_RULE, DELETE_RULE
+        FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
+        WHERE CONSTRAINT_SCHEMA = :schema
+    """)
+    with engine.connect() as conn:
+        rows = conn.execute(q, {"schema": schema}).mappings().all()
+    return {
+        r["CONSTRAINT_NAME"]: {
+            "on_update": r.get("UPDATE_RULE"),
+            "on_delete": r.get("DELETE_RULE"),
+        }
+        for r in rows
+    }
+
+
+# --------------------------- Construção do catálogo ---------------------------
+
+
+def build_table_dict(
+    engine: Engine,
+    schema: str,
+    table: str,
+    inspector,
+    sample_rows: int = 0,
+    *,
+    fk_rules: Optional[Dict[str, Dict[str, Optional[str]]]] = None,
+    mask_pii: bool = False,
+    max_text_len: Optional[int] = None,
+) -> Dict[str, Any]:
+    # Comentário da tabela
+    tcomment = inspector.get_table_comment(table_name=table, schema=schema) or {}
+    tbl: Dict[str, Any] = {
+        "name": table,
+        "comment": tcomment.get("text") or "",
+        "columns": [],
+        "primary_key": [],
+        "foreign_keys": [],
+        "indexes": [],
+    }
+
+    # Colunas
+    for col in inspector.get_columns(table, schema=schema):
+        # (5) autoincrement -> booleano sempre
+        ai = col.get("autoincrement")
+        ai_bool = bool(ai)
+        tbl["columns"].append({
+            "name": col.get("name"),
+            "type": normalize_type(col.get("type")),  # (3) minúsculas
+            "nullable": bool(col.get("nullable")),
+            "default": col.get("default"),
+            "autoincrement": ai_bool,                 # (5)
+            "comment": (col.get("comment") or ""),
+        })
+
+    # PK
+    pk = inspector.get_pk_constraint(table, schema=schema) or {}
+    tbl["primary_key"] = pk.get("constrained_columns") or []
+
+    # FKs
+    for fk in inspector.get_foreign_keys(table, schema=schema):
+        fk_entry = {
+            "name": fk.get("name"),
+            "columns": fk.get("constrained_columns") or [],
+            "ref_schema": fk.get("referred_schema"),
+            "ref_table": fk.get("referred_table"),
+            "ref_columns": fk.get("referred_columns") or [],
+            "on_update": (fk.get("options") or {}).get("onupdate"),
+            "on_delete": (fk.get("options") or {}).get("ondelete"),
+        }
+        # (2) complementar via REFERENTIAL_CONSTRAINTS pelo nome da constraint
+        if fk_rules and fk_entry["name"] in fk_rules:
+            if not fk_entry["on_update"]:
+                fk_entry["on_update"] = fk_rules[fk_entry["name"]]["on_update"]
+            if not fk_entry["on_delete"]:
+                fk_entry["on_delete"] = fk_rules[fk_entry["name"]]["on_delete"]
+        tbl["foreign_keys"].append(fk_entry)
+
+    # Índices (inclui UNIQUE e não-únicos)
+    for idx in inspector.get_indexes(table, schema=schema):
+        tbl["indexes"].append({
+            "name": idx.get("name"),
+            "unique": bool(idx.get("unique")),
+            "columns": idx.get("column_names") or [],
+            "type": idx.get("type"),  # pode ser None
+        })
+
+    # Amostra de linhas (opcional)
+    if sample_rows and sample_rows > 0:
+        try:
+            with engine.connect() as conn:
+                col_names = [c["name"] for c in inspector.get_columns(table, schema=schema)]
+                if not col_names:
+                    tbl["sample_rows"] = []
+                else:
+                    cols_sql = ", ".join(f"`{c}`" for c in col_names)
+                    sql = text(f"SELECT {cols_sql} FROM `{schema}`.`{table}` LIMIT :lim")
+                    rows = conn.execute(sql, {"lim": int(sample_rows)}).mappings().all()
+
+                    def _norm_row(d):
+                        base = dict(d)
+                        if mask_pii:
+                            return {k: mask_pii_value(v, max_text_len) for k, v in base.items()}
+                        else:
+                            return {k: json_fallback(v) for k, v in base.items()}
+
+                    tbl["sample_rows"] = [_norm_row(r) for r in rows]
+        except SQLAlchemyError:
+            tbl["sample_rows"] = []
+
+    return tbl
+
+
+def to_markdown(catalog: Dict[str, Any]) -> str:
+    """Gera um resumo Markdown compacto para prompt/visualização humana."""
+    lines: List[str] = []
+    lines.append(f"# Catálogo — schema `{catalog.get('schema','')}`")
+    lines.append("")
+    for t in catalog.get("tables", []):
+        lines.append(f"## {t['name']}")
+        if t.get("comment"):
+            lines.append(f"> {t['comment']}")
+        # Resumo de colunas
+        cols = []
+        for c in t["columns"]:
+            col_bits = [f"`{c['name']}` {c['type']}"]
+            if not c["nullable"]:
+                col_bits.append("NOT NULL")
+            if c.get("default") is not None:
+                col_bits.append(f"DEFAULT {c['default']}")
+            if c.get("comment"):
+                col_bits.append(f"// {c['comment']}")
+            cols.append(" - " + " | ".join(col_bits))
+        if cols:
+            lines.append("**Colunas:**")
+            lines.extend(cols)
+        # PK
+        if t.get("primary_key"):
+            lines.append(f"**PK:** {', '.join('`'+c+'`' for c in t['primary_key'])}")
+        # FKs
+        if t.get("foreign_keys"):
+            lines.append("**FKs:**")
+            for fk in t["foreign_keys"]:
+                src = ", ".join(f"`{c}`" for c in fk["columns"])
+                dst_cols = ", ".join(f"`{c}`" for c in (fk["ref_columns"] or []))
+                ref = f"`{fk.get('ref_table')}`({dst_cols})"
+                ou = f" ON UPDATE {fk['on_update']}" if fk.get("on_update") else ""
+                od = f" ON DELETE {fk['on_delete']}" if fk.get("on_delete") else ""
+                lines.append(f" - {src} → {ref}{ou}{od}")
+        # Índices
+        if t.get("indexes"):
+            lines.append("**Índices:**")
+            for idx in t["indexes"]:
+                cols_join = ", ".join(f"`{c}`" for c in (idx.get("columns") or []))
+                uniq = " UNIQUE" if idx.get("unique") else ""
+                lines.append(f" - `{idx.get('name')}`{uniq} ({cols_join})")
+        # Amostra (se houver)
+        if t.get("sample_rows"):
+            lines.append("**Amostra:**")
+            for r in t["sample_rows"]:
+                lines.append(" - " + ", ".join(f"`{k}`={repr(v)}" for k, v in r.items()))
+        lines.append("")
+    return "\n".join(lines)
+
+
+def export_db_catalog(
+    url: str,
+    *,
+    schema: Optional[str] = None,
+    include_views: bool = False,
+    sample_rows: int = 0,
+    mask_pii: bool = False,
+    max_text_len: int = 160,
+) -> str:
+    """
+    Exporta o catálogo do MariaDB como JSON (string).
+
+    Parâmetros:
+      - url: URL SQLAlchemy (ex.: mariadb+mariadbconnector://user:pass@host:3306/db)
+      - schema: nome do schema/banco; se None, tenta descobrir via SELECT DATABASE()
+      - include_views: se True, inclui views
+      - sample_rows: N linhas de amostra por tabela (0 desliga)
+      - mask_pii: se True, mascara e-mail/CPF/telefone e achata textos nas amostras
+      - max_text_len: limite de tamanho de textos em amostras (válido com mask_pii)
+
+    Retorna:
+      - JSON (str) com o catálogo.
+    """
+    engine = create_engine(url, pool_pre_ping=True)
+
+    eff_schema = schema or guess_schema_from_url(engine)
+    if not eff_schema:
+        raise ValueError("Não foi possível determinar o schema. Informe 'schema=' ou ajuste a URL.")
+
+    insp = inspect(engine)
+
+    # Tabelas e (opcional) views
+    tables = list(insp.get_table_names(schema=eff_schema))
+    if include_views:
+        tables.extend(insp.get_view_names(schema=eff_schema))
+
+    # Regras ON UPDATE/DELETE por constraint
+    fk_rules = load_fk_rules(engine, eff_schema)
+
+    catalog: Dict[str, Any] = {"schema": eff_schema, "tables": []}
+
+    for t in tables:
+        try:
+            print(f"Exportando tabela/view: {t}")
+
+            catalog["tables"].append(
+                    build_table_dict(
+                        engine,
+                        eff_schema,
+                        t,
+                        insp,
+                        sample_rows=sample_rows,
+                        fk_rules=fk_rules,
+                        mask_pii=mask_pii,
+                        max_text_len=max_text_len,
+                    )
+                )
+        except SQLAlchemyError as e:
+            print(f"Falha ao inspecionar a tabela: {e}")
+
+            catalog["tables"].append({
+                "name": t,
+                "error": f"Falha ao inspecionar a tabela: {e}",
+            })
+
+    return json.dumps(catalog, ensure_ascii=False, indent=2, default=json_fallback)

--- a/src/tools/verx_rh_tools.py
+++ b/src/tools/verx_rh_tools.py
@@ -1,0 +1,193 @@
+from typing import List, Dict, Any
+import re, json
+from langchain_openai import ChatOpenAI
+from langchain_core.tools import tool
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.output_parsers import StrOutputParser
+from sqlalchemy import text
+
+from src.services.database import DB, ENGINE
+from src.config import OPENAI_API_KEY, MARIADB_URI
+from src.services.nl2sql import export_db_catalog
+
+
+def build_llm():
+    return ChatOpenAI(
+        model="gpt-4o-mini",
+        temperature=0,
+        api_key=OPENAI_API_KEY,
+    )
+
+
+def _enforce_allowed_tables(sql: str) -> None:
+    """Função mantida para compatibilidade, mas não faz mais verificações
+    já que o controle de acesso é feito via schema seguro e permissões do usuário."""
+    # O controle agora é feito via schema seguro e permissões do usuário
+    pass
+
+
+def _validate_select_only(sql: str) -> str:
+    # Adicionar logs para debug
+    print(f"SQL recebido para validação: '{sql}'")
+    print(f"Primeiros 10 caracteres (representação): {repr(sql[:10])}")
+    
+    # Remover marcadores de código Markdown se presentes
+    if sql.startswith('```'):
+        # Encontra o final do bloco de código
+        end_marker = sql.rfind('```')
+        if end_marker > 3:  # Certifica-se de que há um marcador de fim
+            # Extrai apenas o conteúdo entre os marcadores
+            # Pula a primeira linha se contiver apenas ```sql ou similar
+            lines = sql[3:end_marker].strip().split('\n')
+            if lines[0].strip().lower() in ['sql', 'mysql', 'mariadb']:
+                sql = '\n'.join(lines[1:]).strip()
+            else:
+                sql = '\n'.join(lines).strip()
+            print(f"SQL após remoção de marcadores Markdown: '{sql}'")
+    
+    # Normalizar a string removendo espaços extras e caracteres invisíveis
+    normalized_sql = sql.strip()
+    
+    # Verificar se começa com SELECT
+    if not re.match(r"(?i)^\s*select\b", normalized_sql, re.IGNORECASE):
+        print(f"ERRO: SQL não começa com SELECT: '{normalized_sql}'")
+        raise ValueError("Somente consultas SELECT são permitidas.")
+    
+    # Impõe LIMIT se não houver
+    if not re.search(r"\blimit\s+\d+\s*;?\s*$", normalized_sql, re.IGNORECASE):
+        normalized_sql = normalized_sql.rstrip().rstrip(";") + " LIMIT 200;"
+        print(f"SQL com LIMIT adicionado: '{normalized_sql}'")
+    
+    return normalized_sql
+
+
+# Cadeia NL → SQL
+def build_nl2sql_chain() -> str:
+    llm = build_llm()
+
+    prompt = ChatPromptTemplate.from_messages([
+        ("system",
+        "Você gera SQL para MariaDB. Regras:\n"
+        "- Gere apenas UM único SELECT válido.\n"
+        "- Não use DML/DDL (INSERT/UPDATE/DELETE/CREATE/etc.).\n"
+        "- Utilize apenas tabelas/colunas existentes no schema abaixo.\n"
+        "- Se precisar limitar linhas, use LIMIT.\n"
+        "- Para campos de texto (VARCHAR, CHAR, TEXT), use LIKE com wildcards para busca parcial.\n"
+        "- Quando buscar por nomes ou outros campos de texto, use LIKE '%termo%' em vez de = 'termo'.\n"
+        "- Exemplo: use 'nome LIKE \'%Gabriel%Silveira%\'' em vez de 'nome = \'Gabriel Silveira\'' para encontrar 'Gabriel Silveira de Souza'.\n"),
+        ("system", "Schema disponível:\n{schema}"),
+        ("human", "Pergunta do usuário:\n{question}\n\n"
+            "Saída esperada: apenas o SQL (sem comentários nem explicações)."),
+    ])
+
+    return prompt | llm | StrOutputParser()
+
+
+# --------- Ferramentas ---------
+
+@tool("VerxRH_RunQuery", return_direct=False)
+def VerxRH_RunQuery(sql: str) -> Dict[str, Any]:
+    """Executa SQL (somente SELECT) no MariaDB e retorna linhas como JSON."""
+    safe_sql = _validate_select_only(sql)
+
+    with ENGINE.connect() as conn:
+        conn.execute(text("SET SESSION time_zone = '+00:00'"))
+        res = conn.execute(text(safe_sql))
+        
+        # Converter resultados para dicionário e tratar tipos de dados não serializáveis
+        rows = []
+        for r in res:
+            row_dict = dict(r._mapping)
+            # Converter objetos date/datetime para string ISO
+            for key, value in row_dict.items():
+                if hasattr(value, 'isoformat'):  # Verifica se é date, datetime ou similar
+                    row_dict[key] = value.isoformat()
+            rows.append(row_dict)
+
+    return {"sql": safe_sql, "rows": rows, "row_count": len(rows)}
+
+
+@tool("VerxRH_GetDBCatalog", return_direct=False)
+def VerxRH_GetDBCatalog() -> str:
+    """Exporta o catálogo do MariaDB como JSON (string)."""
+
+    print("Obtendo catálogo do banco...")
+
+    catalog = export_db_catalog(
+        url=MARIADB_URI,
+        sample_rows=0,
+        mask_pii=True,
+        max_text_len=160,
+        include_views=True,
+    )
+
+    return catalog
+
+@tool("db_list_tables", return_direct=False)
+def db_list_tables(_: str = "") -> List[str]:
+    """Lista nomes de tabelas do banco que o agente pode usar."""
+    return sorted(DB.get_usable_table_names())
+
+
+@tool("db_query", return_direct=False)
+def db_query(sql: str) -> Dict[str, Any]:
+    """Executa SQL (somente SELECT) no MariaDB e retorna linhas como JSON.
+    Garante LIMIT e recusa comandos de escrita."""
+
+    _enforce_allowed_tables(sql)
+
+    safe_sql = _validate_select_only(sql)
+
+    with ENGINE.connect() as conn:
+        conn.execute(text("SET SESSION time_zone = '+00:00'"))
+        res = conn.execute(text(safe_sql))
+        rows = [dict(r._mapping) for r in res]
+
+    return {"sql": safe_sql, "rows": rows, "row_count": len(rows)}
+
+
+@tool("db_nl2sql_rows", return_direct=True)
+def db_nl2sql_rows(question: str) -> str:
+    """
+    Recebe uma pergunta em linguagem natural, gera um SELECT e retorna APENAS os resultados em JSON (array de objetos).
+    """
+
+    # 1) Debug
+    print(f"Pergunta: {question}\n\n")
+
+    # 1) Schema (pode otimizar passando só as tabelas candidatas)
+    # Usando .invoke() em vez de chamar diretamente
+    table_names = db_list_tables.invoke("")
+    schema = DB.get_table_info(table_names)
+
+    # 1.5) Debug
+    print(f"Schema: {schema}\n\n")
+
+    # 2) Gera SQL
+    chain = build_nl2sql_chain()
+    sql = chain.invoke({"schema": schema, "question": question}).strip()
+
+    # 2.5) Debug
+    print(f"SQL gerado: {sql}\n\n")
+
+    # 3) Segurança
+    _enforce_allowed_tables(sql)
+    safe_sql = _validate_select_only(sql)
+
+    # 4) Executa e retorna SOMENTE os rows em JSON
+    with ENGINE.connect() as conn:
+        conn.execute(text("SET SESSION time_zone = '+00:00'"))
+        result = conn.execute(text(safe_sql))
+        
+        # Converter resultados para dicionário e tratar tipos de dados não serializáveis
+        rows = []
+        for r in result:
+            row_dict = dict(r._mapping)
+            # Converter objetos date/datetime para string ISO
+            for key, value in row_dict.items():
+                if hasattr(value, 'isoformat'):  # Verifica se é date, datetime ou similar
+                    row_dict[key] = value.isoformat()
+            rows.append(row_dict)
+
+    # Retorna JSON puro (string). Como return_direct=True, o agente repassa isso sem alterações.
+    return json.dumps(rows, ensure_ascii=False)

--- a/uv.lock
+++ b/uv.lock
@@ -1643,7 +1643,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "0.3.68"
+version = "0.3.74"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -1654,9 +1654,9 @@ dependencies = [
     { name = "tenacity" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/23/20/f5b18a17bfbe3416177e702ab2fd230b7d168abb17be31fb48f43f0bb772/langchain_core-0.3.68.tar.gz", hash = "sha256:312e1932ac9aa2eaf111b70fdc171776fa571d1a86c1f873dcac88a094b19c6f", size = 563041, upload-time = "2025-07-03T17:02:28.704Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/c6/5d755a0f1f4857abbe5ea6f5907ed0e2b5df52bf4dde0a0fd768290e3084/langchain_core-0.3.74.tar.gz", hash = "sha256:ff604441aeade942fbcc0a3860a592daba7671345230c2078ba2eb5f82b6ba76", size = 569553, upload-time = "2025-08-07T20:47:05.094Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/da/c89be0a272993bfcb762b2a356b9f55de507784c2755ad63caec25d183bf/langchain_core-0.3.68-py3-none-any.whl", hash = "sha256:5e5c1fbef419590537c91b8c2d86af896fbcbaf0d5ed7fdcdd77f7d8f3467ba0", size = 441405, upload-time = "2025-07-03T17:02:27.115Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/26/545283681ac0379d31c7ad0bac5f195e1982092d76c65ca048db9e3cec0e/langchain_core-0.3.74-py3-none-any.whl", hash = "sha256:088338b5bc2f6a66892f9afc777992c24ee3188f41cbc603d09181e34a228ce7", size = 443453, upload-time = "2025-08-07T20:47:03.853Z" },
 ]
 
 [[package]]
@@ -1700,7 +1700,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "0.5.1"
+version = "0.6.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
@@ -1710,9 +1710,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/72/db/864d8e6c6e921f27b357980d0cfca847366238c1bb8a6bffd766f651004e/langgraph-0.5.1.tar.gz", hash = "sha256:312d341979e38034dde60e08df53505b8a196619df1266d6eacf6b002a0a65a8", size = 437339, upload-time = "2025-07-02T21:15:56.581Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/ea/ce85312450e98a01d0974da404fa7572f2a90ec01013f8d2dfd94b714b67/langgraph-0.6.5.tar.gz", hash = "sha256:59639927997457fe04f802b39f0e7179cedf8db1cf85f33db764de02ae23c2f0", size = 455213, upload-time = "2025-08-13T23:42:35.063Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/fa/69e83057b7a6062c0785deccdd22610003611c16cac7b4218b4b87c4924a/langgraph-0.5.1-py3-none-any.whl", hash = "sha256:707f0cc0d2713011fff4578bf57de8226cd96bcc0679868be2f41eb0984bb5af", size = 143695, upload-time = "2025-07-02T21:15:55.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/09/93774886995cccb9110280887f7b489e5b951bbc928f078a9788254290be/langgraph-0.6.5-py3-none-any.whl", hash = "sha256:042b2ee7af6f308659520eea5ba6def50f2d109475691666045850d0661b1082", size = 153154, upload-time = "2025-08-13T23:42:33.263Z" },
 ]
 
 [[package]]
@@ -1730,28 +1730,28 @@ wheels = [
 
 [[package]]
 name = "langgraph-prebuilt"
-version = "0.5.1"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph-checkpoint" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a6/8a/91d1bba787c0a8792eb6ef583718a0885b92f1bceec8e229deb2ef02977d/langgraph_prebuilt-0.5.1.tar.gz", hash = "sha256:43a361612b8fb9784338bfc481245e3422ca366ca8e43f68c4c6723d7eb8b9f4", size = 117843, upload-time = "2025-06-27T14:42:03.889Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/21/9b198d11732101ee8cdf30af98d0b4f11254c768de15173e57f5260fd14b/langgraph_prebuilt-0.6.4.tar.gz", hash = "sha256:e9e53b906ee5df46541d1dc5303239e815d3ec551e52bb03dd6463acc79ec28f", size = 125695, upload-time = "2025-08-07T18:17:57.333Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/7c/18b74ad8f1a5c8ef7f058dddbef4cd881c25df9620599e32e47fb6c1f829/langgraph_prebuilt-0.5.1-py3-none-any.whl", hash = "sha256:60a752c62a954fab816e9047e1dd05df8f2fabbdf59e1c745d9e2f700202662f", size = 23794, upload-time = "2025-06-27T14:42:03.019Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/7f/973b0d9729d9693d6e5b4bc5f3ae41138d194cb7b16b0ed230020beeb13a/langgraph_prebuilt-0.6.4-py3-none-any.whl", hash = "sha256:819f31d88b84cb2729ff1b79db2d51e9506b8fb7aaacfc0d359d4fe16e717344", size = 28025, upload-time = "2025-08-07T18:17:56.493Z" },
 ]
 
 [[package]]
 name = "langgraph-sdk"
-version = "0.1.72"
+version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "orjson" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/a6/cf13ace9bc7f0e8b13852ced0b37ece97f3140e232821c28bc852f8c1ea2/langgraph_sdk-0.1.72.tar.gz", hash = "sha256:396d8195881830700e2d54a0a9ee273e8b1173428e667502ef9c182a3cec7ab7", size = 71600, upload-time = "2025-06-27T01:12:03.788Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/3e/3dc45dc7682c9940db9edaf8773d2e157397c5bd6881f6806808afd8731e/langgraph_sdk-0.2.0.tar.gz", hash = "sha256:cd8b5f6595e5571be5cbffd04cf936978ab8f5d1005517c99715947ef871e246", size = 72510, upload-time = "2025-07-22T17:31:06.745Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/4b/d56b51da08d168c2315cd092faa47bc83388b116756dbd6995026ec9ba3f/langgraph_sdk-0.1.72-py3-none-any.whl", hash = "sha256:925d3fcc7a26361db04f9c4beb3ec05bc36361b2a836d181ff2ab145071ec3ce", size = 50129, upload-time = "2025-06-27T01:12:02.449Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/03/a8ab0e8ea74be6058cb48bb1d85485b5c65d6ea183e3ee1aa8ca1ac73b3e/langgraph_sdk-0.2.0-py3-none-any.whl", hash = "sha256:150722264f225c4d47bbe7394676be102fdbf04c4400a0dd1bd41a70c6430cc7", size = 50569, upload-time = "2025-07-22T17:31:04.582Z" },
 ]
 
 [[package]]
@@ -1804,6 +1804,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9e/38/bd5b78a920a64d708fe6bc8e0a2c075e1389d53bef8413725c63ba041535/mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28", size = 392474, upload-time = "2025-04-10T12:44:31.16Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/87/fb/99f81ac72ae23375f22b7afdb7642aba97c00a713c217124420147681a2f/mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59", size = 78509, upload-time = "2025-04-10T12:50:53.297Z" },
+]
+
+[[package]]
+name = "mariadb"
+version = "1.1.13"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b0/a0/0498c90f46940b6fd7f5c76d22df9f011849964e94e0b22fde26c42191c7/mariadb-1.1.13.tar.gz", hash = "sha256:3a0fd24fae2b9990dc13a0a427a43d4a5434cc2a8c3b260a27f40b7824719037", size = 111126, upload-time = "2025-07-11T09:55:11.147Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/b4/d961a5dfa8a7a04ede70f76f85b951b8d0ec28d79b86ced829a67af78bdd/mariadb-1.1.13-cp312-cp312-win32.whl", hash = "sha256:358ecdc8775f4a97357fc233bb84a1c8d8d52866ee5fe98f2d13e9e58a04b6fb", size = 185334, upload-time = "2025-07-11T09:54:59.901Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/3b/16cc69a9c90f91b74c096c0cb9634e14692486beb28b82ec5efd97866de7/mariadb-1.1.13-cp312-cp312-win_amd64.whl", hash = "sha256:0604c57e6f90ff7ef190a56894d2b32ca5f0182924b5159be9319ba243ffbf98", size = 202109, upload-time = "2025-07-11T09:55:01.846Z" },
+    { url = "https://files.pythonhosted.org/packages/02/16/583719e127774294d4af085a063b38f20407801cd9194a676334fb121edd/mariadb-1.1.13-cp313-cp313-win32.whl", hash = "sha256:36c644c13ecf3e38cb89f37f9bd054703760b94c881476492fe789801a063ce3", size = 185301, upload-time = "2025-07-11T09:55:03.486Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/da/4170f5532813ffba2641f821ed23ed1f22fa3ff8d603e47c91b0776ff9b7/mariadb-1.1.13-cp313-cp313-win_amd64.whl", hash = "sha256:6ec51ad2e33312c397cfcc5e2bca59861f572d5e8880e025d43db9a5d472a3a9", size = 202105, upload-time = "2025-07-11T09:55:05.681Z" },
 ]
 
 [[package]]
@@ -1899,11 +1914,15 @@ dependencies = [
     { name = "fastapi" },
     { name = "gunicorn" },
     { name = "langchain-arcade" },
+    { name = "langchain-community" },
+    { name = "langchain-core" },
     { name = "langchain-openai" },
     { name = "langgraph" },
+    { name = "mariadb" },
     { name = "pyjwt" },
     { name = "python-dotenv" },
     { name = "python-multipart" },
+    { name = "sqlalchemy" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "youtube-transcript-api" },
     { name = "yt-dlp" },
@@ -1930,8 +1949,11 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.24.0" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12.0" },
     { name = "langchain-arcade", specifier = ">=1.3.1" },
+    { name = "langchain-community", specifier = ">=0.3.27" },
+    { name = "langchain-core", specifier = ">=0.3.74" },
     { name = "langchain-openai", specifier = ">=0.2.5" },
-    { name = "langgraph", specifier = ">=0.5.1" },
+    { name = "langgraph", specifier = ">=0.6.4" },
+    { name = "mariadb", specifier = ">=1.1.13" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.5.1" },
     { name = "pyjwt", specifier = ">=2.10.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.0" },
@@ -1939,6 +1961,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
     { name = "python-multipart", specifier = ">=0.0.20" },
+    { name = "sqlalchemy", specifier = ">=2.0.43" },
     { name = "uvicorn", extras = ["standard"], specifier = "==0.34.3" },
     { name = "youtube-transcript-api", specifier = ">=1.1.1" },
     { name = "yt-dlp", specifier = "==2023.11.14" },
@@ -3601,31 +3624,31 @@ wheels = [
 
 [[package]]
 name = "sqlalchemy"
-version = "2.0.41"
+version = "2.0.43"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "greenlet", marker = "(python_full_version < '3.14' and platform_machine == 'AMD64') or (python_full_version < '3.14' and platform_machine == 'WIN32') or (python_full_version < '3.14' and platform_machine == 'aarch64') or (python_full_version < '3.14' and platform_machine == 'amd64') or (python_full_version < '3.14' and platform_machine == 'ppc64le') or (python_full_version < '3.14' and platform_machine == 'win32') or (python_full_version < '3.14' and platform_machine == 'x86_64')" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/63/66/45b165c595ec89aa7dcc2c1cd222ab269bc753f1fc7a1e68f8481bd957bf/sqlalchemy-2.0.41.tar.gz", hash = "sha256:edba70118c4be3c2b1f90754d308d0b79c6fe2c0fdc52d8ddf603916f83f4db9", size = 9689424, upload-time = "2025-05-14T17:10:32.339Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/bc/d59b5d97d27229b0e009bd9098cd81af71c2fa5549c580a0a67b9bed0496/sqlalchemy-2.0.43.tar.gz", hash = "sha256:788bfcef6787a7764169cfe9859fe425bf44559619e1d9f56f5bddf2ebf6f417", size = 9762949, upload-time = "2025-08-11T14:24:58.438Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/2a/f1f4e068b371154740dd10fb81afb5240d5af4aa0087b88d8b308b5429c2/sqlalchemy-2.0.41-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:81f413674d85cfd0dfcd6512e10e0f33c19c21860342a4890c3a2b59479929f9", size = 2119645, upload-time = "2025-05-14T17:55:24.854Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/e8/c664a7e73d36fbfc4730f8cf2bf930444ea87270f2825efbe17bf808b998/sqlalchemy-2.0.41-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:598d9ebc1e796431bbd068e41e4de4dc34312b7aa3292571bb3674a0cb415dd1", size = 2107399, upload-time = "2025-05-14T17:55:28.097Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/78/8a9cf6c5e7135540cb682128d091d6afa1b9e48bd049b0d691bf54114f70/sqlalchemy-2.0.41-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a104c5694dfd2d864a6f91b0956eb5d5883234119cb40010115fd45a16da5e70", size = 3293269, upload-time = "2025-05-14T17:50:38.227Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/35/f74add3978c20de6323fb11cb5162702670cc7a9420033befb43d8d5b7a4/sqlalchemy-2.0.41-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6145afea51ff0af7f2564a05fa95eb46f542919e6523729663a5d285ecb3cf5e", size = 3303364, upload-time = "2025-05-14T17:51:49.829Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/d4/c990f37f52c3f7748ebe98883e2a0f7d038108c2c5a82468d1ff3eec50b7/sqlalchemy-2.0.41-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b46fa6eae1cd1c20e6e6f44e19984d438b6b2d8616d21d783d150df714f44078", size = 3229072, upload-time = "2025-05-14T17:50:39.774Z" },
-    { url = "https://files.pythonhosted.org/packages/15/69/cab11fecc7eb64bc561011be2bd03d065b762d87add52a4ca0aca2e12904/sqlalchemy-2.0.41-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41836fe661cc98abfae476e14ba1906220f92c4e528771a8a3ae6a151242d2ae", size = 3268074, upload-time = "2025-05-14T17:51:51.736Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/ca/0c19ec16858585d37767b167fc9602593f98998a68a798450558239fb04a/sqlalchemy-2.0.41-cp312-cp312-win32.whl", hash = "sha256:a8808d5cf866c781150d36a3c8eb3adccfa41a8105d031bf27e92c251e3969d6", size = 2084514, upload-time = "2025-05-14T17:55:49.915Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/23/4c2833d78ff3010a4e17f984c734f52b531a8c9060a50429c9d4b0211be6/sqlalchemy-2.0.41-cp312-cp312-win_amd64.whl", hash = "sha256:5b14e97886199c1f52c14629c11d90c11fbb09e9334fa7bb5f6d068d9ced0ce0", size = 2111557, upload-time = "2025-05-14T17:55:51.349Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/ad/2e1c6d4f235a97eeef52d0200d8ddda16f6c4dd70ae5ad88c46963440480/sqlalchemy-2.0.41-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4eeb195cdedaf17aab6b247894ff2734dcead6c08f748e617bfe05bd5a218443", size = 2115491, upload-time = "2025-05-14T17:55:31.177Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/8d/be490e5db8400dacc89056f78a52d44b04fbf75e8439569d5b879623a53b/sqlalchemy-2.0.41-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d4ae769b9c1c7757e4ccce94b0641bc203bbdf43ba7a2413ab2523d8d047d8dc", size = 2102827, upload-time = "2025-05-14T17:55:34.921Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/72/c97ad430f0b0e78efaf2791342e13ffeafcbb3c06242f01a3bb8fe44f65d/sqlalchemy-2.0.41-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a62448526dd9ed3e3beedc93df9bb6b55a436ed1474db31a2af13b313a70a7e1", size = 3225224, upload-time = "2025-05-14T17:50:41.418Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/51/5ba9ea3246ea068630acf35a6ba0d181e99f1af1afd17e159eac7e8bc2b8/sqlalchemy-2.0.41-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc56c9788617b8964ad02e8fcfeed4001c1f8ba91a9e1f31483c0dffb207002a", size = 3230045, upload-time = "2025-05-14T17:51:54.722Z" },
-    { url = "https://files.pythonhosted.org/packages/78/2f/8c14443b2acea700c62f9b4a8bad9e49fc1b65cfb260edead71fd38e9f19/sqlalchemy-2.0.41-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c153265408d18de4cc5ded1941dcd8315894572cddd3c58df5d5b5705b3fa28d", size = 3159357, upload-time = "2025-05-14T17:50:43.483Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/b2/43eacbf6ccc5276d76cea18cb7c3d73e294d6fb21f9ff8b4eef9b42bbfd5/sqlalchemy-2.0.41-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4f67766965996e63bb46cfbf2ce5355fc32d9dd3b8ad7e536a920ff9ee422e23", size = 3197511, upload-time = "2025-05-14T17:51:57.308Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/2e/677c17c5d6a004c3c45334ab1dbe7b7deb834430b282b8a0f75ae220c8eb/sqlalchemy-2.0.41-cp313-cp313-win32.whl", hash = "sha256:bfc9064f6658a3d1cadeaa0ba07570b83ce6801a1314985bf98ec9b95d74e15f", size = 2082420, upload-time = "2025-05-14T17:55:52.69Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/61/e8c1b9b6307c57157d328dd8b8348ddc4c47ffdf1279365a13b2b98b8049/sqlalchemy-2.0.41-cp313-cp313-win_amd64.whl", hash = "sha256:82ca366a844eb551daff9d2e6e7a9e5e76d2612c8564f58db6c19a726869c1df", size = 2108329, upload-time = "2025-05-14T17:55:54.495Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/fc/9ba22f01b5cdacc8f5ed0d22304718d2c758fce3fd49a5372b886a86f37c/sqlalchemy-2.0.41-py3-none-any.whl", hash = "sha256:57df5dc6fdb5ed1a88a1ed2195fd31927e705cad62dedd86b46972752a80f576", size = 1911224, upload-time = "2025-05-14T17:39:42.154Z" },
+    { url = "https://files.pythonhosted.org/packages/61/db/20c78f1081446095450bdc6ee6cc10045fce67a8e003a5876b6eaafc5cc4/sqlalchemy-2.0.43-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:20d81fc2736509d7a2bd33292e489b056cbae543661bb7de7ce9f1c0cd6e7f24", size = 2134891, upload-time = "2025-08-11T15:51:13.019Z" },
+    { url = "https://files.pythonhosted.org/packages/45/0a/3d89034ae62b200b4396f0f95319f7d86e9945ee64d2343dcad857150fa2/sqlalchemy-2.0.43-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:25b9fc27650ff5a2c9d490c13c14906b918b0de1f8fcbb4c992712d8caf40e83", size = 2123061, upload-time = "2025-08-11T15:51:14.319Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/10/2711f7ff1805919221ad5bee205971254845c069ee2e7036847103ca1e4c/sqlalchemy-2.0.43-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6772e3ca8a43a65a37c88e2f3e2adfd511b0b1da37ef11ed78dea16aeae85bd9", size = 3320384, upload-time = "2025-08-11T15:52:35.088Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0e/3d155e264d2ed2778484006ef04647bc63f55b3e2d12e6a4f787747b5900/sqlalchemy-2.0.43-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1a113da919c25f7f641ffbd07fbc9077abd4b3b75097c888ab818f962707eb48", size = 3329648, upload-time = "2025-08-11T15:56:34.153Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/81/635100fb19725c931622c673900da5efb1595c96ff5b441e07e3dd61f2be/sqlalchemy-2.0.43-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4286a1139f14b7d70141c67a8ae1582fc2b69105f1b09d9573494eb4bb4b2687", size = 3258030, upload-time = "2025-08-11T15:52:36.933Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ed/a99302716d62b4965fded12520c1cbb189f99b17a6d8cf77611d21442e47/sqlalchemy-2.0.43-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:529064085be2f4d8a6e5fab12d36ad44f1909a18848fcfbdb59cc6d4bbe48efe", size = 3294469, upload-time = "2025-08-11T15:56:35.553Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/a2/3a11b06715149bf3310b55a98b5c1e84a42cfb949a7b800bc75cb4e33abc/sqlalchemy-2.0.43-cp312-cp312-win32.whl", hash = "sha256:b535d35dea8bbb8195e7e2b40059e2253acb2b7579b73c1b432a35363694641d", size = 2098906, upload-time = "2025-08-11T15:55:00.645Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/09/405c915a974814b90aa591280623adc6ad6b322f61fd5cff80aeaef216c9/sqlalchemy-2.0.43-cp312-cp312-win_amd64.whl", hash = "sha256:1c6d85327ca688dbae7e2b06d7d84cfe4f3fffa5b5f9e21bb6ce9d0e1a0e0e0a", size = 2126260, upload-time = "2025-08-11T15:55:02.965Z" },
+    { url = "https://files.pythonhosted.org/packages/41/1c/a7260bd47a6fae7e03768bf66451437b36451143f36b285522b865987ced/sqlalchemy-2.0.43-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e7c08f57f75a2bb62d7ee80a89686a5e5669f199235c6d1dac75cd59374091c3", size = 2130598, upload-time = "2025-08-11T15:51:15.903Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/84/8a337454e82388283830b3586ad7847aa9c76fdd4f1df09cdd1f94591873/sqlalchemy-2.0.43-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:14111d22c29efad445cd5021a70a8b42f7d9152d8ba7f73304c4d82460946aaa", size = 2118415, upload-time = "2025-08-11T15:51:17.256Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/ff/22ab2328148492c4d71899d62a0e65370ea66c877aea017a244a35733685/sqlalchemy-2.0.43-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:21b27b56eb2f82653168cefe6cb8e970cdaf4f3a6cb2c5e3c3c1cf3158968ff9", size = 3248707, upload-time = "2025-08-11T15:52:38.444Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/29/11ae2c2b981de60187f7cbc84277d9d21f101093d1b2e945c63774477aba/sqlalchemy-2.0.43-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c5a9da957c56e43d72126a3f5845603da00e0293720b03bde0aacffcf2dc04f", size = 3253602, upload-time = "2025-08-11T15:56:37.348Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/61/987b6c23b12c56d2be451bc70900f67dd7d989d52b1ee64f239cf19aec69/sqlalchemy-2.0.43-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d79f9fdc9584ec83d1b3c75e9f4595c49017f5594fee1a2217117647225d738", size = 3183248, upload-time = "2025-08-11T15:52:39.865Z" },
+    { url = "https://files.pythonhosted.org/packages/86/85/29d216002d4593c2ce1c0ec2cec46dda77bfbcd221e24caa6e85eff53d89/sqlalchemy-2.0.43-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9df7126fd9db49e3a5a3999442cc67e9ee8971f3cb9644250107d7296cb2a164", size = 3219363, upload-time = "2025-08-11T15:56:39.11Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/e4/bd78b01919c524f190b4905d47e7630bf4130b9f48fd971ae1c6225b6f6a/sqlalchemy-2.0.43-cp313-cp313-win32.whl", hash = "sha256:7f1ac7828857fcedb0361b48b9ac4821469f7694089d15550bbcf9ab22564a1d", size = 2096718, upload-time = "2025-08-11T15:55:05.349Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/a5/ca2f07a2a201f9497de1928f787926613db6307992fe5cda97624eb07c2f/sqlalchemy-2.0.43-cp313-cp313-win_amd64.whl", hash = "sha256:971ba928fcde01869361f504fcff3b7143b47d30de188b11c6357c0505824197", size = 2123200, upload-time = "2025-08-11T15:55:07.932Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/d9/13bdde6521f322861fab67473cec4b1cc8999f3871953531cf61945fad92/sqlalchemy-2.0.43-py3-none-any.whl", hash = "sha256:1681c21dd2ccee222c2fe0bef671d1aef7c504087c9c4e800371cfcc8ac966fc", size = 1924759, upload-time = "2025-08-11T15:39:53.024Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Correção na execução de ferramentas personalizadas no MCP Server

## Problema

O servidor MCP estava apresentando erros ao executar ferramentas personalizadas como `VerxRH_RunQuery` e `VerxRH_GetDBCatalog`:

1. **Erro de ferramenta não encontrada**: 
   ```
   Error executing tool 'Verxrh_RunQuery': Tool 'Verxrh_RunQuery' not found in this manager instance
   ```

2. **Erro de argumento posicional**:
   ```
   BaseTool.__call__() missing 1 required positional argument: 'tool_input'
   ```

3. **Erro de serialização JSON**:
   ```
   Error executing tool 'VerxRH_RunQuery': Object of type date is not JSON serializable
   ```

## Alterações realizadas

### 1. Correção na nomenclatura das ferramentas

Padronizamos os nomes das ferramentas para manter consistência entre a definição e a chamada:

- Renomeamos `Verxrh_RunQuery` para `VerxRH_RunQuery`
- Renomeamos `Verxrh_GetDBCatalog` para `VerxRH_GetDBCatalog`

### 2. Correção no método de execução das ferramentas personalizadas

Substituímos o uso do método `__call__` (obsoleto desde a versão 0.1.47 do LangChain) pelo método `invoke` recomendado na documentação:

```python
# Antes (incorreto)
result = tool(**cleaned_arguments)

# Depois (correto)
result = tool.invoke(cleaned_arguments)
```

### 3. Tratamento específico para cada ferramenta personalizada

Implementamos tratamento específico para cada ferramenta personalizada, respeitando seus requisitos de argumentos:

```python
if tool_name == "VerxRH_RunQuery":
    # VerxRH_RunQuery espera um argumento 'sql'
    sql = cleaned_arguments.get("sql", "")
    result = tool.invoke({"sql": sql})
elif tool_name == "VerxRH_GetDBCatalog":
    # VerxRH_GetDBCatalog não espera argumentos
    result = tool.invoke({})
else:
    # Para outras ferramentas personalizadas
    result = tool.invoke(cleaned_arguments)
```

### 4. Tratamento de tipos de dados não serializáveis em JSON

Adicionamos código para converter objetos `date` e `datetime` para strings no formato ISO 8601:

```python
# Converter resultados para dicionário e tratar tipos de dados não serializáveis
rows = []
for r in res:
    row_dict = dict(r._mapping)
    # Converter objetos date/datetime para string ISO
    for key, value in row_dict.items():
        if hasattr(value, 'isoformat'):  # Verifica se é date, datetime ou similar
            row_dict[key] = value.isoformat()
    rows.append(row_dict)
```

## Arquivos modificados

1. `/src/tools/base.py`: Modificado para usar o método `invoke` corretamente com as ferramentas personalizadas
2. `/src/tools/verx_rh_tools.py`: Corrigido os nomes das ferramentas e adicionado tratamento para tipos de dados não serializáveis

## Impacto

Estas alterações permitem que as ferramentas personalizadas `VerxRH_RunQuery` e `VerxRH_GetDBCatalog` sejam executadas corretamente através do servidor MCP, sem erros de ferramenta não encontrada, argumentos incorretos ou problemas de serialização JSON.

## Referências

- [Documentação do LangChain sobre ferramentas](https://python.langchain.com/docs/introduction/how_to/custom_tools)
- [Aviso de depreciação do método `__call__`](https://python.langchain.com/docs/introduction/versions/v0_2/deprecations)
